### PR TITLE
fix(docker-image): update public.ecr.aws/docker/library/redis docker …

### DIFF
--- a/kubernetes/doc-home-cluster/infrastructure/security/oauth2-proxy/redis/helmrelease.yaml
+++ b/kubernetes/doc-home-cluster/infrastructure/security/oauth2-proxy/redis/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
 
     image:
       repository: public.ecr.aws/docker/library/redis
-      tag: 7.0.10
+      tag: 7.0.11
 
     podAnnotations:
       secret.reloader.stakater.com/reload: oauth2-proxy-redis-secrets


### PR DESCRIPTION
…tag to v7.0.11

| datasource | package                             | from   | to     |
| ---------- | ----------------------------------- | ------ | ------ |
| docker     | public.ecr.aws/docker/library/redis | 7.0.10 | 7.0.11 |