### PR TITLE
feat(docker-image): update 1password-connect group to v1.7.0

### DIFF
--- a/kubernetes/doc-home-cluster/infrastructure/security/external-secrets/stores/onepassword/helmrelease.yaml
+++ b/kubernetes/doc-home-cluster/infrastructure/security/external-secrets/stores/onepassword/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
                 reloader.stakater.com/auto: "true"
         image:
             repository: docker.io/1password/connect-api
-            tag: 1.6.1
+            tag: 1.7.0
         env:
             OP_BUS_PORT: "11220"
             OP_BUS_PEERS: localhost:11221
@@ -95,7 +95,7 @@ spec:
         sidecars:
             sync:
                 name: sync
-                image: docker.io/1password/connect-sync:1.6.1@sha256:2b551430ea8e3acf5b5d053cc8b05daffea1ec8181cc1e55d7b6c3bd05d9868d
+                image: docker.io/1password/connect-sync:1.7.0@sha256:fdc300b6c4c6593cee76e09c9e5099165f5c74d6561f5accd9006eb1b31cc306
                 env:
                     - name: OP_SESSION
                       valueFrom:


### PR DESCRIPTION
| datasource | package                          | from  | to    |
| ---------- | -------------------------------- | ----- | ----- |
| docker     | docker.io/1password/connect-api  | 1.6.1 | 1.7.0 |
| docker     | docker.io/1password/connect-sync | 1.6.1 | 1.7.0 |