### PR TITLE
🔧 chore: add plex.tv FQDN rule to network policy

### DIFF
--- a/kubernetes/apps/media/plex/plex-auto-languages/networkpolicy.yaml
+++ b/kubernetes/apps/media/plex/plex-auto-languages/networkpolicy.yaml
@@ -17,3 +17,10 @@ spec:
         - ports:
             - port: "32400"
               protocol: TCP
+
+    - toFQDNs:
+        - matchName: plex.tv
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
Allow plex-auto-languages to communicate with plex.tv on port 443