### PR TITLE
chore: replace archived pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,31 +28,37 @@ repos:
       - id: check-merge-conflict
       - id: check-executables-have-shebangs
 
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+  - repo: local
     hooks:
-      - id: forbid-crlf
       - id: forbid-tabs
+        name: Forbid hard tabs
+        entry: uv run python precommit_hooks/forbid_tabs.py
+        language: python
+        types: [text]
 
-  - repo: https://github.com/sirosen/fix-smartquotes
-    rev: 0.2.0
-    hooks:
-      - id: fix-smartquotes
+      - id: normalize-smartquotes
+        name: Normalize smart quotes
+        entry: uv run python precommit_hooks/normalize_smartquotes.py
+        language: python
+        types: [text]
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
       - id: prettier
+        name: Prettier
+        entry: prettier --write
+        language: node
+        additional_dependencies:
+          - prettier@3.3.3
         files: \.(json5?|ya?ml|md|markdown)$
         exclude: |
           (?x)^(
               .*\.sops\.yaml$
             | .*\.sops\.yml$
           )$
-  - repo: https://github.com/k8s-at-home/sops-pre-commit
-    rev: v2.1.1
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.28.0
     hooks:
-      - id: forbid-secrets
+      - id: gitleaks
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.18.1

--- a/precommit_hooks/forbid_tabs.py
+++ b/precommit_hooks/forbid_tabs.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+
+def main(paths: List[str]) -> int:
+    offending: List[Path] = []
+
+    for name in paths:
+        path = Path(name)
+        try:
+            text = path.read_text()
+        except UnicodeDecodeError:
+            continue
+
+        if "\t" in text:
+            offending.append(path)
+
+    if offending:
+        for path in offending:
+            print(f"Tabs found in {path}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/precommit_hooks/normalize_smartquotes.py
+++ b/precommit_hooks/normalize_smartquotes.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import sys
+import unicodedata
+from pathlib import Path
+from typing import List
+
+_REPLACEMENTS = {
+    0x2018: "'",
+    0x2019: "'",
+    0x201C: '"',
+    0x201D: '"',
+}
+
+
+def normalize_text(text: str) -> str:
+    return unicodedata.normalize("NFKC", text).translate(_REPLACEMENTS)
+
+
+def main(paths: List[str]) -> int:
+    for name in paths:
+        path = Path(name)
+        try:
+            original = path.read_text()
+        except UnicodeDecodeError:
+            continue
+
+        normalized = normalize_text(original)
+        if normalized != original:
+            path.write_text(normalized)
+            print(f"Normalized smart quotes in {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
    - replace the external tab and smart-quote hooks with in-repo python helpers
    - run prettier through npm so we’re no longer pinned to the archived mirror
    - switch the sops secret check to gitleaks for broader secret detection