### PR TITLE
Wire split OpenClaw Hermes and Honcho sources

### DIFF
--- a/kubernetes/apps/database/crunchy-postgres-operator/cluster/postgrescluster.yaml
+++ b/kubernetes/apps/database/crunchy-postgres-operator/cluster/postgrescluster.yaml
@@ -108,6 +108,11 @@ spec:
         - metamcp
       password:
         type: AlphaNumeric
+    - name: honcho
+      databases:
+        - honcho
+      password:
+        type: AlphaNumeric
     - name: tandoor
       databases:
         - tandoor

--- a/kubernetes/apps/selfhosted/hermes/ks.yaml
+++ b/kubernetes/apps/selfhosted/hermes/ks.yaml
@@ -35,6 +35,32 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: honcho
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: honcho
+  interval: 30m
+  timeout: 5m
+  path: "./hermes/honcho"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: openclaw
+    namespace: selfhosted
+  wait: false
+  dependsOn:
+    - name: openclaw-source
+      namespace: selfhosted
+    - name: onepassword-store
+      namespace: external-secrets
+    - name: crunchy-postgres-operator-cluster
+      namespace: database
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: &appname hermes
 spec:
   commonMetadata:
@@ -42,7 +68,7 @@ spec:
       app.kubernetes.io/name: *appname
   interval: 30m
   timeout: 5m
-  path: "./app"
+  path: "./hermes/app"
   prune: true
   sourceRef:
     kind: GitRepository
@@ -53,6 +79,8 @@ spec:
     - name: openclaw-source
       namespace: selfhosted
     - name: hermes-volsync
+      namespace: selfhosted
+    - name: honcho
       namespace: selfhosted
     - name: onepassword-store
       namespace: external-secrets

--- a/kubernetes/apps/selfhosted/openclaw/ks.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/ks.yaml
@@ -69,7 +69,7 @@ spec:
       app.kubernetes.io/name: *appname
   interval: 30m
   timeout: 5m
-  path: "./"
+  path: "./openclaw/app"
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
- Point OpenClaw Flux Kustomization at the new openclaw/app path
- Add a dedicated Honcho Kustomization sourced from the OpenClaw repo
- Point Hermes at hermes/app and make it depend on Honcho
- Add the honcho database/user to the shared Crunchy Postgres cluster

## Validation
- Parsed touched YAML files with Ruby Psych
- Ran git diff --check on the touched files

## Notes
- honcho_redis_password must exist in the hermes 1Password item before reconciliation
- pgvector is intentionally handled manually in the honcho database