### PR TITLE
[codex] Fix system-upgrade-controller service account token

### DIFF
--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
         replicas: 2
 
         pod:
+          automountServiceAccountToken: true
           securityContext:
             runAsNonRoot: true
             runAsUser: 65534


### PR DESCRIPTION
## Summary

- explicitly enables `automountServiceAccountToken` for the `system-upgrade-controller` pod
- restores the in-cluster Kubernetes client credentials expected by `rancher/system-upgrade-controller`

## Root cause

The live Deployment in `system-upgrade` is rendering `spec.template.spec.automountServiceAccountToken: false`. The controller then starts without `/var/run/secrets/kubernetes.io/serviceaccount/token` and exits with:

```text
error creating inClusterConfig, falling back to default config: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory
invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```

Both current controller pods were in `CrashLoopBackOff` when checked.

## Validation

- `kubectl kustomize kubernetes/apps/system-upgrade/system-upgrade-controller/app`
- `kubectl kustomize kubernetes/apps/system-upgrade/system-upgrade-controller/plans`
- `git diff --check`

## Notes

After merge, Flux should reconcile the HelmRelease and roll out a pod with the service account token mounted.