### PR TITLE
[codex] Fix Zigbee2MQTT EMQX endpoint

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
@@ -66,7 +66,7 @@ spec:
               ZIGBEE2MQTT_CONFIG_MQTT_INCLUDE_DEVICE_INFORMATION: "true"
               ZIGBEE2MQTT_CONFIG_MQTT_KEEPALIVE: 60
               ZIGBEE2MQTT_CONFIG_MQTT_REJECT_UNAUTHORIZED: "true"
-              ZIGBEE2MQTT_CONFIG_MQTT_SERVER: "mqtt://emqx-listeners.database.svc.cluster.local:1883"
+              ZIGBEE2MQTT_CONFIG_MQTT_SERVER: "mqtt://emqx-headless.database.svc.cluster.local:1883"
               ZIGBEE2MQTT_CONFIG_MQTT_VERSION: 5
               ZIGBEE2MQTT_CONFIG_MQTT_USER:
                 valueFrom:


### PR DESCRIPTION
## Summary

- Point Zigbee2MQTT at the EMQX headless service instead of the EMQX listener LoadBalancer service.
- This makes DNS resolve to EMQX backend pod IPs, which are already allowed by the existing Cilium endpoint policy on TCP/1883.

## Root cause

Zigbee2MQTT was dialing `emqx-listeners.database.svc.cluster.local:1883`, which resolves to the service ClusterIP. Cilium denied that service-frontend connection with `connect EPERM`, even though direct EMQX pod IP connectivity was allowed. The headless service path bypasses the blocked service frontend and uses the already-permitted backend endpoints.

## Validation

- Confirmed the original Zigbee2MQTT error: `MQTT failed to connect ... connect EPERM 10.106.46.246:1883`.
- Confirmed direct EMQX pod IP connectivity succeeds while `emqx-listeners` ClusterIP connectivity fails.
- Confirmed `emqx-headless.database.svc.cluster.local:1883` connectivity succeeds.
- Ran `mise exec -- just flux build-ks dir=home-automation/zigbee2mqtt`; render completed, with the repo's existing invalid `dependsOn` warning.
- Applied the same endpoint live as temporary drift and verified Zigbee2MQTT logs show `Connected to MQTT server` and `zigbee2mqtt/bridge/state` published `online`.