### PR TITLE
fix(emqx): rebuild broker on supported 5.10 release

### DIFF
--- a/kubernetes/apps/database/emqx/cluster/cluster.yaml
+++ b/kubernetes/apps/database/emqx/cluster/cluster.yaml
@@ -1,11 +1,11 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/apps.emqx.io/emqx_v2beta1.json
-apiVersion: apps.emqx.io/v2beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/apps.emqx.io/emqx_v2.json
+apiVersion: apps.emqx.io/v2
 kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: public.ecr.aws/emqx/emqx:5.8.9
+  image: emqx/emqx:5.10.3
   config:
     data: |
       authentication {
@@ -36,7 +36,9 @@ spec:
       annotations:
         reloader.stakater.com/auto: "true"
     spec:
-      replicas: 2
+      # EMQX 5.9+ requires a license for clustered deployments.
+      # Keep a single core until a license secret is wired into the cluster.
+      replicas: 1
       envFrom:
         - secretRef:
             name: emqx-secret
@@ -59,4 +61,7 @@ spec:
         external-dns.alpha.kubernetes.io/hostname: "mqtt.piscio.net"
         lbipam.cilium.io/ips: 192.168.32.156
     spec:
+      # Keep listener endpoints published during broker rebuilds so clients can
+      # reconnect as soon as a new pod is accepting MQTT.
+      publishNotReadyAddresses: true
       type: LoadBalancer

--- a/kubernetes/apps/database/emqx/ks.yaml
+++ b/kubernetes/apps/database/emqx/ks.yaml
@@ -45,7 +45,7 @@ spec:
     - name: onepassword-store
       namespace: external-secrets
   healthCheckExprs:
-    - apiVersion: apps.emqx.io/v2beta1
+    - apiVersion: apps.emqx.io/v2
       kind: EMQX
       failed: status.conditions.filter(e, e.type == 'Available').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'Available').all(e, e.status == 'True')

--- a/kubernetes/apps/database/ks.yaml
+++ b/kubernetes/apps/database/ks.yaml
@@ -45,7 +45,7 @@ spec:
     - name: onepassword-store
       namespace: external-secrets
   healthCheckExprs:
-    - apiVersion: apps.emqx.io/v2beta1
+    - apiVersion: apps.emqx.io/v2
       kind: EMQX
       failed: status.conditions.filter(e, e.type == 'Available').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'Available').all(e, e.status == 'True')


### PR DESCRIPTION
## Summary
- Move the EMQX CR to `apps.emqx.io/v2`
- Rebuild EMQX on `emqx/emqx:5.10.3`, which matches the already-deployed EMQX Operator 2.3 compatibility line
- Run a single core replica because EMQX 5.9+ requires a license for clustered deployments and this repo does not currently wire a license secret
- Keep `publishNotReadyAddresses: true` on the listener service so MQTT clients can reconnect as soon as the fresh broker accepts traffic
- Update Flux health checks to `apps.emqx.io/v2`

## Live test
This PR was tested manually in the cluster before merge:
1. Exported rollback manifests to `/private/tmp/emqx-rebuild-test`
2. Suspended `flux-system/cluster-apps` and `database/emqx-cluster`
3. Deleted the stale EMQX CR, which removed the stale 5.8.x StatefulSets and services
4. Applied this branch's EMQX CR fresh
5. Waited for the new EMQX pod `emqx-core-6bfd9dc854-0` to become Ready on image `emqx/emqx:5.10.3`
6. Restarted Zigbee2MQTT so discovery/state was republished into the fresh broker

## Verification
- EMQX reports Ready=True / Available=True / CoreNodesReady=True
- `emqx-listeners` exists with LoadBalancer IP `192.168.32.156`
- Home Assistant is connected to MQTT with 105 subscriptions
- Zigbee2MQTT is connected to MQTT with 2 subscriptions
- Zigbee2MQTT logs show Home Assistant discovery config topics being republished
- `kubectl kustomize kubernetes/apps/database/emqx/cluster`
- `kubectl apply --dry-run=server -f kubernetes/apps/database/emqx/cluster/cluster.yaml`
- `git diff --check`