### PR TITLE
Revert "Update Rook-Ceph group ( v1.19.6 ➔ v1.20.0 )"

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.0
+    tag: v1.19.6
   url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/kubernetes/apps/rook-ceph/rook-ceph/operator/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/operator/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.0
+    tag: v1.19.6
   url: oci://ghcr.io/rook/rook-ceph


### PR DESCRIPTION
Reverts D-o-c-labs/Doc-Home-ops#5049