### PR TITLE
[codex] Fix Renovate custom managers and roll Rook Ceph forward

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -1,0 +1,8 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "github>home-operations/renovate-presets//managers/oci.json5#2.0.0",
+    "github>D-o-c-labs/Doc-Home-ops//.renovate/grafanaDashboards.json5",
+    "github>home-operations/renovate-presets//managers/talosFactory.json5#2.0.0",
+  ],
+}

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.6
+    tag: v1.20.0
   url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/kubernetes/apps/rook-ceph/rook-ceph/operator/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/operator/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.19.6
+    tag: v1.20.0
   url: oci://ghcr.io/rook/rook-ceph

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,7 +7,7 @@
     "github>D-o-c-labs/Doc-Home-ops//.renovate/autoMerge.json5",
     "github>D-o-c-labs/Doc-home-ops//.renovate/versioning.json5",
     "github>D-o-c-labs/Doc-Home-ops//.renovate/groups.json5",
-    "github>bjw-s-labs/home-ops//.renovate/grafanaDashboards.json5",
+    "github>D-o-c-labs/Doc-Home-ops//.renovate/customManagers.json5",
     "config:recommended",
     ":dependencyDashboard",
   ],


### PR DESCRIPTION
## Summary
- Replace the deleted bjw-s-labs Grafana dashboards Renovate preset with a repo-local customManagers preset.
- Follow bjw-s' current pattern by extending home-operations Renovate manager presets pinned at 2.0.0, while preserving this repo's existing Grafana dashboard manager.
- Roll both Rook-Ceph OCI chart sources forward from v1.19.6 to v1.20.0.

## Root cause
Renovate was aborting during config initialization because github>bjw-s-labs/home-ops//.renovate/grafanaDashboards.json5 now returns 404. Rook/Ceph rollback left the cluster running older Ceph v19.2.3 binaries against storage metadata that appears to have been advanced by the attempted upgrade, so this rolls forward again for follow-up cluster diagnosis.

## Validation
- npx --yes --package renovate@43 renovate-config-validator renovate.json5
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' kubernetes/apps/rook-ceph/rook-ceph/operator/ocirepository.yaml kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
- pre-commit run --files renovate.json5 .renovate/customManagers.json5 kubernetes/apps/rook-ceph/rook-ceph/operator/ocirepository.yaml kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml