### PR TITLE
Install Rook ceph-csi-drivers chart

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: ceph-csi-drivers
+      version: 1.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: ceph-csi-operator
+      interval: 30m
+  values:
+    operatorConfig:
+      namespace: rook-ceph
+      driverSpecDefaults:
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        nodePlugin:
+          priorityClassName: system-node-critical
+        controllerPlugin:
+          priorityClassName: system-cluster-critical
+    drivers:
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+      cephfs:
+        enabled: true
+        name: rook-ceph.cephfs.csi.ceph.com
+        snapshotPolicy: none
+        kernelMountOptions:
+          ms_mode: prefer-crc
+      nfs:
+        enabled: false
+        name: rook-ceph.nfs.csi.ceph.com
+      nvmeof:
+        enabled: false
+        name: rook-ceph.nvmeof.csi.ceph.com

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ceph-csi-operator
+spec:
+  interval: 30m
+  url: https://ceph.github.io/ceph-csi-operator

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -22,6 +22,32 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: &appname ceph-csi-drivers
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/apps/rook-ceph/rook-ceph/csi-drivers"
+  prune: false # Never delete this
+  dependsOn:
+    - name: rook-ceph
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: ceph-csi-drivers
+      namespace: rook-ceph
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: &appname rook-ceph-cluster
 spec:
   commonMetadata:
@@ -31,6 +57,8 @@ spec:
   timeout: 5m
   path: "./kubernetes/apps/rook-ceph/rook-ceph/cluster"
   prune: false # Never delete this
+  dependsOn:
+    - name: ceph-csi-drivers
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/rook-ceph/rook-ceph/operator/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/operator/helmrelease.yaml
@@ -14,10 +14,6 @@ spec:
     crds:
       enabled: true
     csi:
-      cephFSKernelMountOptions: ms_mode=prefer-crc
-      enableCephfsDriver: true
-      enableCephfsSnapshotter: false
-      enableLiveness: true
       serviceMonitor:
         enabled: true
     enableDiscoveryDaemon: true


### PR DESCRIPTION
## Summary
- Install the ceph-csi-drivers Helm chart required by Rook v1.20.
- Wire Flux ordering as rook-ceph -> ceph-csi-drivers -> rook-ceph-cluster.
- Move stale CSI driver settings out of the rook-ceph operator chart values and preserve the local CephFS mount and snapshot choices in the drivers chart.

## Why
Rook v1.20 changed CSI driver management. The rook-ceph chart installs the ceph-csi-operator, but the CSI driver resources must be installed with the separate ceph-csi-drivers chart. The upgrade guide explicitly warns that missing this chart leaves CSI failed due to missing service accounts.

The cluster matches that failure mode: the live Driver and OperatorConfig CRs are annotated for a ceph-csi-drivers Helm release, but that release is absent, and the CSI nodeplugin DaemonSets are failing because their required service accounts and RBAC are missing.

## Validation
- kubectl kustomize kubernetes/apps/rook-ceph/rook-ceph/csi-drivers
- kubectl kustomize kubernetes/apps/rook-ceph/rook-ceph/operator
- kubectl kustomize --load-restrictor LoadRestrictionsNone kubernetes/apps/rook-ceph
- helm template ceph-csi-drivers ceph-csi-operator/ceph-csi-drivers with the PR values
- kubectl apply --dry-run=server against the rendered ceph-csi-drivers chart resources
- pre-commit run on the changed Rook files