### PR TITLE
Enable drift correction for Ceph CSI drivers

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -14,6 +14,8 @@ spec:
         kind: HelmRepository
         name: ceph-csi-operator
       interval: 30m
+  driftDetection:
+    mode: enabled
   values:
     operatorConfig:
       namespace: rook-ceph


### PR DESCRIPTION
## Summary
- enable Flux Helm drift detection for the ceph-csi-drivers HelmRelease

## Why
The ceph-csi-drivers chart installed successfully, and Helm storage contains the desired Driver resources with the prefixed chart-managed service account names. The live Driver CRs are still drifted from that manifest: their serviceAccountName fields are empty, so ceph-csi-operator keeps generating nodeplugin DaemonSets that reference rbd-nodeplugin-sa and cephfs-nodeplugin-sa.

Flux Helm drift detection is designed for this exact case: correcting differences between the Helm storage manifest and the resources currently in the cluster.

## Validation
- kubectl kustomize kubernetes/apps/rook-ceph/rook-ceph/csi-drivers
- pre-commit run --files kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml

## Current live evidence
- ceph-csi-drivers HelmRelease is Ready and installed chart 1.0.1
- live Driver CRs still have empty nodePlugin/controllerPlugin serviceAccountName fields
- CSI nodeplugin DaemonSets still use rbd-nodeplugin-sa / cephfs-nodeplugin-sa and remain desired=3 current=2 ready=2