### PR TITLE
Restore Ceph CSI controller host networking

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -25,17 +25,25 @@ spec:
         nodePlugin:
           priorityClassName: system-node-critical
         controllerPlugin:
+          hostNetwork: true
           priorityClassName: system-cluster-critical
+          replicas: 2
     drivers:
       rbd:
         enabled: true
         name: rook-ceph.rbd.csi.ceph.com
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
       cephfs:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
         snapshotPolicy: none
         kernelMountOptions:
           ms_mode: prefer-crc
+        controllerPlugin:
+          hostNetwork: true
+          replicas: 2
       nfs:
         enabled: false
         name: rook-ceph.nfs.csi.ceph.com


### PR DESCRIPTION
## Summary
- restore host networking for RBD and CephFS CSI controller plugins
- restore two CSI controller replicas in the chart-managed Driver specs and OperatorConfig defaults

## Why
The cluster is not running old Flux config: ceph-csi-drivers is applied from main, driftDetection is enabled, and the Driver CRs have the chart-managed service accounts.

The current failure is different: RBD CSI controller sidecars are flapping. The RBD controller pod has hundreds of restarts, the attacher exits because it loses /csi/csi.sock, and stale VolumeAttachments such as actual-budget remain stuck with external-attacher finalizers. The actual-budget PV is still attached to zeus while the pod is scheduled on ares.

Before moving CSI into the separate chart, the live OperatorConfig had controllerPlugin.hostNetwork=true and replicas=2. The first chart install did not preserve those defaults, so drift detection changed the chart-managed Driver CRs to hostNetwork=false and replicas=1. This PR restores the previous controller networking/replica behavior in the chart values.

## Validation
- kubectl kustomize kubernetes/apps/rook-ceph/rook-ceph/csi-drivers
- pre-commit run --files kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
- helm template ceph-csi-drivers ceph-csi-operator/ceph-csi-drivers with the proposed values; rendered Driver CRs contain hostNetwork=true and replicas=2 for RBD and CephFS controllers